### PR TITLE
Refactor the creation of unresolved objects and QPDF::parse_xrefEntry 

### DIFF
--- a/include/qpdf/QPDF.hh
+++ b/include/qpdf/QPDF.hh
@@ -1024,7 +1024,8 @@ class QPDF
     bool resolveXRefTable();
     void reconstruct_xref(QPDFExc& e);
     bool parse_xrefFirst(std::string const& line, int& obj, int& num, int& bytes);
-    bool parse_xrefEntry(std::string const& line, qpdf_offset_t& f1, int& f2, char& type);
+    bool read_xrefEntry(qpdf_offset_t& f1, int& f2, char& type);
+    bool read_bad_xrefEntry(qpdf_offset_t& f1, int& f2, char& type);
     qpdf_offset_t read_xrefTable(qpdf_offset_t offset);
     qpdf_offset_t read_xrefStream(qpdf_offset_t offset);
     qpdf_offset_t processXRefStream(qpdf_offset_t offset, QPDFObjectHandle& xref_stream);

--- a/include/qpdf/QPDF.hh
+++ b/include/qpdf/QPDF.hh
@@ -814,7 +814,8 @@ class QPDF
         }
     };
 
-    // The ParseGuard class allows QPDFParser to detect re-entrant parsing.
+    // The ParseGuard class allows QPDFParser to detect re-entrant parsing. It also provides
+    // special access to allow the parser to create unresolved objects and dangling references.
     class ParseGuard
     {
         friend class QPDFParser;
@@ -827,6 +828,13 @@ class QPDF
                 qpdf->inParse(true);
             }
         }
+
+        static std::shared_ptr<QPDFObject>
+        getObject(QPDF* qpdf, int id, int gen)
+        {
+            return qpdf->getObjectForParser(id, gen);
+        }
+
         ~ParseGuard()
         {
             if (qpdf) {
@@ -1052,13 +1060,13 @@ class QPDF
     void resolve(QPDFObjGen og);
     void resolveObjectsInStream(int obj_stream_number);
     void stopOnError(std::string const& message);
-    QPDFObjectHandle reserveObjectIfNotExists(QPDFObjGen const& og);
     QPDFObjectHandle reserveStream(QPDFObjGen const& og);
     QPDFObjGen nextObjGen();
     QPDFObjectHandle newIndirect(QPDFObjGen const&, std::shared_ptr<QPDFObject> const&);
     QPDFObjectHandle makeIndirectFromQPDFObject(std::shared_ptr<QPDFObject> const& obj);
     bool isCached(QPDFObjGen const& og);
     bool isUnresolved(QPDFObjGen const& og);
+    std::shared_ptr<QPDFObject> getObjectForParser(int id, int gen);
     void removeObject(QPDFObjGen og);
     void updateCache(
         QPDFObjGen const& og,

--- a/libqpdf/QPDF.cc
+++ b/libqpdf/QPDF.cc
@@ -2,6 +2,7 @@
 
 #include <qpdf/QPDF.hh>
 
+#include <array>
 #include <atomic>
 #include <cstring>
 #include <limits>
@@ -767,11 +768,15 @@ QPDF::parse_xrefFirst(std::string const& line, int& obj, int& num, int& bytes)
 }
 
 bool
-QPDF::parse_xrefEntry(std::string const& line, qpdf_offset_t& f1, int& f2, char& type)
+QPDF::read_bad_xrefEntry(qpdf_offset_t& f1, int& f2, char& type)
 {
+    // Reposition after initial read attempt and reread.
+    m->file->seek(m->file->getLastOffset(), SEEK_SET);
+    auto line = m->file->readLine(30);
+
     // is_space and is_digit both return false on '\0', so this will not overrun the null-terminated
     // buffer.
-    char const* p = line.c_str();
+    char const* p = line.data();
 
     // Skip zero or more spaces. There aren't supposed to be any.
     bool invalid = false;
@@ -842,18 +847,73 @@ QPDF::parse_xrefEntry(std::string const& line, qpdf_offset_t& f1, int& f2, char&
     return true;
 }
 
+// Optimistically read and parse xref entry. If entry is bad, call read_bad_xrefEntry and return
+// result.
+bool
+QPDF::read_xrefEntry(qpdf_offset_t& f1, int& f2, char& type)
+{
+    std::array<char, 21> line;
+    if (m->file->read(line.data(), 20) != 20) {
+        // C++20: [[unlikely]]
+        return false;
+    }
+    line[20] = '\0';
+    char const* p = line.data();
+
+    int f1_len = 0;
+    int f2_len = 0;
+
+    // is_space and is_digit both return false on '\0', so this will not overrun the null-terminated
+    // buffer.
+
+    // Gather f1 digits. NB No risk of overflow as 9'999'999'999 < max long long.
+    while (*p == '0') {
+        ++f1_len;
+        ++p;
+    }
+    while (QUtil::is_digit(*p) && f1_len++ < 10) {
+        f1 *= 10;
+        f1 += *p++ - '0';
+    }
+    // Require space
+    if (!QUtil::is_space(*p++)) {
+        // Entry doesn't start with space or digit.
+        // C++20: [[unlikely]]
+        return false;
+    }
+    // Gather digits. NB No risk of overflow as 99'999 < max int.
+    while (*p == '0') {
+        ++f2_len;
+        ++p;
+    }
+    while (QUtil::is_digit(*p) && f2_len++ < 5) {
+        f2 *= 10;
+        f2 += static_cast<int>(*p++ - '0');
+    }
+    if (QUtil::is_space(*p++) && (*p == 'f' || *p == 'n')) {
+        // C++20: [[likely]]
+        type = *p;
+        ++p;
+        ++p; // No test for valid line[19].
+        if ((*p == '\n' || *p == '\r') && f1_len == 10 && f2_len == 5) {
+            // C++20: [[likely]]
+            return true;
+        }
+    }
+    return read_bad_xrefEntry(f1, f2, type);
+}
+
+// Read a single cross-reference table section and associated trailer.
 qpdf_offset_t
 QPDF::read_xrefTable(qpdf_offset_t xref_offset)
 {
     std::vector<QPDFObjGen> deleted_items;
 
     m->file->seek(xref_offset, SEEK_SET);
-    bool done = false;
-    while (!done) {
-        char linebuf[51];
-        memset(linebuf, 0, sizeof(linebuf));
-        m->file->read(linebuf, sizeof(linebuf) - 1);
-        std::string line = linebuf;
+    std::string line;
+    while (true) {
+        line.assign(50, '\0');
+        m->file->read(line.data(), line.size());
         int obj = 0;
         int num = 0;
         int bytes = 0;
@@ -867,12 +927,11 @@ QPDF::read_xrefTable(qpdf_offset_t xref_offset)
                 // This is needed by checkLinearization()
                 m->first_xref_item_offset = m->file->tell();
             }
-            std::string xref_entry = m->file->readLine(30);
             // For xref_table, these will always be small enough to be ints
             qpdf_offset_t f1 = 0;
             int f2 = 0;
             char type = '\0';
-            if (!parse_xrefEntry(xref_entry, f1, f2, type)) {
+            if (!read_xrefEntry(f1, f2, type)) {
                 QTC::TC("qpdf", "QPDF invalid xref entry");
                 throw damagedPDF(
                     "xref table", "invalid xref entry (obj=" + std::to_string(i) + ")");
@@ -886,7 +945,7 @@ QPDF::read_xrefTable(qpdf_offset_t xref_offset)
         }
         qpdf_offset_t pos = m->file->tell();
         if (readToken(m->file).isWord("trailer")) {
-            done = true;
+            break;
         } else {
             m->file->seek(pos, SEEK_SET);
         }
@@ -945,6 +1004,7 @@ QPDF::read_xrefTable(qpdf_offset_t xref_offset)
     return xref_offset;
 }
 
+// Read a single cross-reference stream.
 qpdf_offset_t
 QPDF::read_xrefStream(qpdf_offset_t xref_offset)
 {

--- a/libqpdf/QPDF.cc
+++ b/libqpdf/QPDF.cc
@@ -1992,30 +1992,36 @@ QPDF::newStream(std::string const& data)
 }
 
 QPDFObjectHandle
-QPDF::reserveObjectIfNotExists(QPDFObjGen const& og)
-{
-    if (!isCached(og) && m->xref_table.count(og) == 0) {
-        updateCache(og, QPDF_Reserved::create(), -1, -1);
-        return newIndirect(og, m->obj_cache[og].object);
-    } else {
-        return getObject(og);
-    }
-}
-
-QPDFObjectHandle
 QPDF::reserveStream(QPDFObjGen const& og)
 {
     return {QPDF_Stream::create(this, og, QPDFObjectHandle::newDictionary(), 0, 0)};
 }
 
+std::shared_ptr<QPDFObject>
+QPDF::getObjectForParser(int id, int gen)
+{
+    // This method is called by the parser and therefore must not resolve any objects.
+    auto og = QPDFObjGen(id, gen);
+    auto [it, inserted] = m->obj_cache.try_emplace(og);
+    auto& obj = it->second.object;
+    if (inserted) {
+        obj = (m->parsed && !m->xref_table.count(og)) ? QPDF_Null::create(this, og)
+                                                      : QPDF_Unresolved::create(this, og);
+    }
+    return obj;
+}
+
 QPDFObjectHandle
 QPDF::getObject(QPDFObjGen const& og)
 {
-    // This method is called by the parser and therefore must not resolve any objects.
-    if (!isCached(og)) {
-        m->obj_cache[og] = ObjCache(QPDF_Unresolved::create(this, og), -1, -1);
+    if (auto it = m->obj_cache.find(og); it != m->obj_cache.end()) {
+        return {it->second.object};
+    } else if (m->parsed && !m->xref_table.count(og)) {
+        return QPDF_Null::create();
+    } else {
+        auto result = m->obj_cache.try_emplace(og, QPDF_Unresolved::create(this, og), -1, -1);
+        return {result.first->second.object};
     }
-    return newIndirect(og, m->obj_cache[og].object);
 }
 
 QPDFObjectHandle

--- a/libqpdf/QPDFParser.cc
+++ b/libqpdf/QPDFParser.cc
@@ -169,7 +169,7 @@ QPDFParser::parseRemainder(bool content_stream)
                     // This action has the desirable side effect of causing dangling references
                     // (references to indirect objects that don't appear in the PDF) in any parsed
                     // object to appear in the object cache.
-                    add(std::move(context->getObject(id, gen).obj));
+                    add(QPDF::ParseGuard::getObject(context, id, gen));
                 } else {
                     QTC::TC("qpdf", "QPDFParser invalid objgen");
                     addNull();

--- a/libqpdf/QPDF_Null.cc
+++ b/libqpdf/QPDF_Null.cc
@@ -3,15 +3,15 @@
 #include <qpdf/JSON_writer.hh>
 #include <qpdf/QPDFObject_private.hh>
 
-QPDF_Null::QPDF_Null() :
-    QPDFValue(::ot_null, "null")
+QPDF_Null::QPDF_Null(QPDF* qpdf, QPDFObjGen og) :
+    QPDFValue(::ot_null, "null", qpdf, og)
 {
 }
 
 std::shared_ptr<QPDFObject>
-QPDF_Null::create()
+QPDF_Null::create(QPDF* qpdf, QPDFObjGen og)
 {
-    return do_create(new QPDF_Null());
+    return do_create(new QPDF_Null(qpdf, og));
 }
 
 std::shared_ptr<QPDFObject>

--- a/libqpdf/QPDF_json.cc
+++ b/libqpdf/QPDF_json.cc
@@ -240,11 +240,6 @@ class QPDF::JSONReactor: public JSON::Reactor
         descr(std::make_shared<QPDFValue::Description>(
             QPDFValue::JSON_Descr(std::make_shared<std::string>(is->getName()), "")))
     {
-        for (auto& oc: pdf.m->obj_cache) {
-            if (oc.second.object->getTypeCode() == ::ot_reserved) {
-                reserved.insert(oc.first);
-            }
-        }
     }
     ~JSONReactor() override = default;
     void dictionaryStart() override;
@@ -305,7 +300,6 @@ class QPDF::JSONReactor: public JSON::Reactor
     bool saw_data{false};
     bool saw_datafile{false};
     bool this_stream_needs_data{false};
-    std::set<QPDFObjGen> reserved;
     std::vector<StackFrame> stack;
     QPDFObjectHandle next_obj;
     state_e next_state{st_top};
@@ -420,12 +414,6 @@ QPDF::JSONReactor::containerEnd(JSON const& value)
         // Handle dangling indirect object references which the PDF spec says to treat as nulls.
         // It's tempting to make this an error, but that would be wrong since valid input files may
         // have these.
-        for (auto& oc: pdf.m->obj_cache) {
-            if (oc.second.object->getTypeCode() == ::ot_reserved && reserved.count(oc.first) == 0) {
-                QTC::TC("qpdf", "QPDF_json non-trivial null reserved");
-                pdf.updateCache(oc.first, QPDF_Null::create(), -1, -1);
-            }
-        }
     }
     if (!stack.empty()) {
         auto state = stack.back().state;
@@ -565,7 +553,7 @@ QPDF::JSONReactor::dictionaryItem(std::string const& key, JSON const& value)
         } else if (is_obj_key(key, obj, gen)) {
             this->cur_object = key;
             if (setNextStateIfDictionary(key, value, st_object_top)) {
-                next_obj = pdf.reserveObjectIfNotExists(QPDFObjGen(obj, gen));
+                next_obj = pdf.getObjectForParser(obj, gen);
             }
         } else {
             QTC::TC("qpdf", "QPDF_json bad object key");
@@ -767,7 +755,7 @@ QPDF::JSONReactor::makeObject(JSON const& value)
         int gen = 0;
         std::string str;
         if (is_indirect_object(str_v, obj, gen)) {
-            result = pdf.reserveObjectIfNotExists(QPDFObjGen(obj, gen));
+            result = pdf.getObjectForParser(obj, gen);
         } else if (is_unicode_string(str_v, str)) {
             result = QPDFObjectHandle::newUnicodeString(str);
         } else if (is_binary_string(str_v, str)) {

--- a/libqpdf/qpdf/QPDF_Null.hh
+++ b/libqpdf/qpdf/QPDF_Null.hh
@@ -7,7 +7,7 @@ class QPDF_Null: public QPDFValue
 {
   public:
     ~QPDF_Null() override = default;
-    static std::shared_ptr<QPDFObject> create();
+    static std::shared_ptr<QPDFObject> create(QPDF* qpdf = nullptr, QPDFObjGen og = QPDFObjGen());
     static std::shared_ptr<QPDFObject> create(
         std::shared_ptr<QPDFObject> parent,
         std::string_view const& static_descr,
@@ -21,7 +21,7 @@ class QPDF_Null: public QPDFValue
     void writeJSON(int json_version, JSON::Writer& p) override;
 
   private:
-    QPDF_Null();
+    QPDF_Null(QPDF* qpdf = nullptr, QPDFObjGen og = QPDFObjGen());
 };
 
 #endif // QPDF_NULL_HH

--- a/libtests/sparse_array.cc
+++ b/libtests/sparse_array.cc
@@ -90,17 +90,17 @@ main()
 
     obj = QPDF_Array::create({10, "null"_qpdf.getObj()}, true);
     QPDF_Array& b = *obj->as<QPDF_Array>();
-    b.setAt(5, pdf.getObject(5, 0));
+    b.setAt(5, pdf.newIndirectNull());
     b.setAt(7, "[0 1 2 3]"_qpdf);
     assert(b.at(3).isNull());
     assert(b.at(8).isNull());
     assert(b.at(5).isIndirect());
-    assert(b.unparse() == "[ null null null null null 5 0 R null [ 0 1 2 3 ] null null ]");
+    assert(b.unparse() == "[ null null null null null 3 0 R null [ 0 1 2 3 ] null null ]");
     auto c = b.copy(true);
     auto d = b.copy(false);
     b.at(7).setArrayItem(2, "42"_qpdf);
-    assert(c->unparse() == "[ null null null null null 5 0 R null [ 0 1 42 3 ] null null ]");
-    assert(d->unparse() == "[ null null null null null 5 0 R null [ 0 1 2 3 ] null null ]");
+    assert(c->unparse() == "[ null null null null null 3 0 R null [ 0 1 42 3 ] null null ]");
+    assert(d->unparse() == "[ null null null null null 3 0 R null [ 0 1 2 3 ] null null ]");
 
     try {
         b.setAt(3, {});

--- a/qpdf/qpdf.testcov
+++ b/qpdf/qpdf.testcov
@@ -673,7 +673,6 @@ QPDF_json ignore second-level key 0
 QPDF_json ignore unknown key in object_top 0
 QPDF_json ignore unknown key in trailer 0
 QPDF_json ignore unknown key in stream 0
-QPDF_json non-trivial null reserved 0
 QPDF_json data and datafile 0
 QPDF_json no stream data in update mode 0
 QPDF_json updating existing stream 0


### PR DESCRIPTION
See qpdf PR1171 and PR1170 for detail.